### PR TITLE
Fix backup path

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -2,4 +2,4 @@
 
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 6
-#define VERSION_MICRO 0
+#define VERSION_MICRO 1

--- a/meta/hbl/meta.xml
+++ b/meta/hbl/meta.xml
@@ -2,7 +2,7 @@
 <app version="1">
     <name>SaveMii WUT</name>
     <coder>DaThinkingChair</coder>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
     <release_date>20220306000000</release_date>
     <short_description>WiiU/vWii Save Manager</short_description>
     <long_description>WiiU/vWii Save Manager

--- a/src/savemng.cpp
+++ b/src/savemng.cpp
@@ -52,7 +52,7 @@ std::string newlibtoFSA(std::string path) {
 }
 
 std::string getBackupPath(uint32_t highId, uint32_t lowId, uint8_t slot){
-    return StringUtils::stringFormat("%s/%08x%08x/%u", backupPath, lowId, highId, slot);
+    return StringUtils::stringFormat("%s/%08x%08x/%u", backupPath, highId, lowId, slot);
 }
 
 std::string getLegacyBackupPath(uint32_t highId, uint32_t lowId){


### PR DESCRIPTION
fixes the backup path.
1.6.0 had the lowID and highID in the path swapped