### PR TITLE
use OSScreen inititalization and ProcUI callbacks from  libwhb's console.c

### DIFF
--- a/include/utils/DrawUtils.h
+++ b/include/utils/DrawUtils.h
@@ -35,7 +35,11 @@ public:
 
     static bool getRedraw() { return redraw; }
 
-    static void initBuffers(void *tvBuffer, uint32_t tvSize, void *drcBuffer, uint32_t drcSize);
+    static BOOL LogConsoleInit();
+
+    static void LogConsoleFree();
+
+    static void initBuffers(void *tvBuffer, void *drcBuffer);
 
     static void beginDraw();
 
@@ -73,12 +77,22 @@ public:
 
     static void drawRGB5A3(int x, int y, float scale, uint8_t *fileContent);
 
+    static uint32_t ConsoleProcCallbackAcquired(void *context);
+
+    static uint32_t ConsoleProcCallbackReleased(void *context);
+
+
+
+
 private:
     static bool redraw;
     static bool isBackBuffer;
 
+
     static uint8_t *tvBuffer;
-    static uint32_t tvSize;
     static uint8_t *drcBuffer;
-    static uint32_t drcSize;
+
+    static void *sBufferTV, *sBufferDRC;
+    static uint32_t sBufferSizeTV, sBufferSizeDRC;
+    static BOOL sConsoleHasForeground;
 };

--- a/include/utils/StateUtils.h
+++ b/include/utils/StateUtils.h
@@ -5,6 +5,7 @@ public:
     static void init();
     static bool AppRunning();
     static void shutdown();
+    static void registerProcUICallbacks();
 
 private:
     static bool aroma;

--- a/src/utils/DrawUtils.cpp
+++ b/src/utils/DrawUtils.cpp
@@ -33,6 +33,7 @@ uint32_t DrawUtils::sBufferSizeDRC = 0;
 static SFT pFont = {};
 
 static Color font_col(0xFFFFFFFF);
+static Color black(0x000000FF);
 
 void *DrawUtils::sBufferTV = NULL, *DrawUtils::sBufferDRC = NULL;
 uint32_t DrawUtils::sBufferSizeTV = 0, DrawUtils::sBufferSizeDRC = 0;
@@ -52,10 +53,25 @@ DrawUtils::ConsoleProcCallbackAcquired(void *context)
       sBufferDRC = MEMAllocFromFrmHeapEx(heap, sBufferSizeDRC, 4);
    }
 
+    
    sConsoleHasForeground = TRUE;
-   DrawUtils::setRedraw(true);
+
    OSScreenSetBufferEx(SCREEN_TV, sBufferTV);
    OSScreenSetBufferEx(SCREEN_DRC, sBufferDRC);
+   DrawUtils::initBuffers(sBufferTV, sBufferDRC);
+
+    OSScreenEnableEx(SCREEN_TV, 1);
+   OSScreenEnableEx(SCREEN_DRC, 1);
+   
+
+   for (int i = 0; i<2; i++) // both buffers to black
+   {
+        DrawUtils::clear(black);
+        DrawUtils::endDraw();
+   }
+
+   DrawUtils::setRedraw(true); // force a redraw when reentering
+
    return 0;
 }
 
@@ -77,12 +93,8 @@ DrawUtils::LogConsoleInit()
    sBufferSizeDRC = OSScreenGetBufferSizeEx(SCREEN_DRC);
 
    ConsoleProcCallbackAcquired(NULL);
-   OSScreenEnableEx(SCREEN_TV, 1);
-   OSScreenEnableEx(SCREEN_DRC, 1);
-
+   
     State::registerProcUICallbacks();
-
-    DrawUtils::initBuffers(sBufferTV, sBufferDRC);
 
    return FALSE;
 }

--- a/src/utils/StateUtils.cpp
+++ b/src/utils/StateUtils.cpp
@@ -3,7 +3,13 @@
 #include <coreinit/foreground.h>
 #include <proc_ui/procui.h>
 #include <utils/StateUtils.h>
+#include <utils/DrawUtils.h>
+#include <coreinit/screen.h>
 #include <whb/proc.h>
+
+#include <string.h>
+
+#include <utils/DrawUtils.h>
 
 bool State::aroma = false;
 
@@ -16,6 +22,14 @@ void State::init() {
         OSEnableHomeButtonMenu(true);
     } else
         WHBProcInit();
+}
+
+
+void State::registerProcUICallbacks() {
+    if (aroma) {
+        ProcUIRegisterCallback(PROCUI_CALLBACK_ACQUIRE, DrawUtils::ConsoleProcCallbackAcquired, NULL, 100);
+        ProcUIRegisterCallback(PROCUI_CALLBACK_RELEASE, DrawUtils::ConsoleProcCallbackReleased, NULL, 100);
+    }
 }
 
 bool State::AppRunning() {
@@ -51,3 +65,5 @@ void State::shutdown() {
         WHBProcShutdown();
     ProcUIShutdown();
 }
+
+


### PR DESCRIPTION
After upgrading to aroma beta 20, savemii 1.6.1 always freezes my wii u when I try to exit the application, and a force reset of the console is needed in order to restart it. Knowing that this behaviour can be caused by how the  procui bg / fg switch is handled, I have modified this part of the code using as a model  the same callbacks and memory allocation code that are used in  libwhb's console.c.
With this changes, the application works ok and I can exit it without problems. I don't know how frequent this problem is, and if this change is  really necessary or not to solve it, but I left it here as a possible starting point to solve this issue. It needs more work for sure. Any comment will be appreciated. 
The Home > Exit application cycle always works as expected. The Home > return to the applicacion sometimes need the touch of a button in order to the screen to be redrawn. If I'm not wrong, this also happens with 1.6.1. This is yet to be solved.