### PR TITLE
Fix for softlocks when initializing/exiting the application and minor issues with backup/restore

### DIFF
--- a/include/savemng.h
+++ b/include/savemng.h
@@ -23,11 +23,6 @@
 #define M_OFF            1
 #define Y_OFF            1
 
-#define COLOR_WHITE      Color(0xffffffff)
-#define COLOR_BLACK      Color(0, 0, 0, 255)
-#define COLOR_BACKGROUND Color(0x00006F00)
-#define COLOR_TEXT       COLOR_WHITE
-
 struct Title {
     uint32_t highID;
     uint32_t lowID;

--- a/include/utils/Colors.h
+++ b/include/utils/Colors.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#define COLOR_WHITE      Color(0xffffffff)
+#define COLOR_BLACK      Color(0, 0, 0, 255)
+#define COLOR_BACKGROUND Color(0x00006F00)
+#define COLOR_TEXT       COLOR_WHITE

--- a/include/utils/DrawUtils.h
+++ b/include/utils/DrawUtils.h
@@ -35,7 +35,11 @@ public:
 
     static bool getRedraw() { return redraw; }
 
-    static void initBuffers(void *tvBuffer, uint32_t tvSize, void *drcBuffer, uint32_t drcSize);
+    static BOOL LogConsoleInit();
+
+    static void LogConsoleFree();
+
+    static void initBuffers(void *tvBuffer, void *drcBuffer);
 
     static void beginDraw();
 
@@ -73,12 +77,22 @@ public:
 
     static void drawRGB5A3(int x, int y, float scale, uint8_t *fileContent);
 
+    static uint32_t ConsoleProcCallbackAcquired(void *context);
+
+    static uint32_t ConsoleProcCallbackReleased(void *context);
+
+
+
+
 private:
     static bool redraw;
     static bool isBackBuffer;
 
+
     static uint8_t *tvBuffer;
-    static uint32_t tvSize;
     static uint8_t *drcBuffer;
-    static uint32_t drcSize;
+
+    static void *sBufferTV, *sBufferDRC;
+    static uint32_t sBufferSizeTV, sBufferSizeDRC;
+    static BOOL sConsoleHasForeground;
 };

--- a/include/utils/DrawUtils.h
+++ b/include/utils/DrawUtils.h
@@ -77,9 +77,9 @@ public:
 
     static void drawRGB5A3(int x, int y, float scale, uint8_t *fileContent);
 
-    static uint32_t ConsoleProcCallbackAcquired(void *context);
+    static uint32_t initScreen();
 
-    static uint32_t ConsoleProcCallbackReleased(void *context);
+    static uint32_t deinitScreen();
 
 
 

--- a/include/utils/DrawUtils.h
+++ b/include/utils/DrawUtils.h
@@ -39,8 +39,6 @@ public:
 
     static void LogConsoleFree();
 
-    static void initBuffers(void *tvBuffer, void *drcBuffer);
-
     static void beginDraw();
 
     static void endDraw();
@@ -92,7 +90,6 @@ private:
     static uint8_t *tvBuffer;
     static uint8_t *drcBuffer;
 
-    static void *sBufferTV, *sBufferDRC;
     static uint32_t sBufferSizeTV, sBufferSizeDRC;
     static BOOL sConsoleHasForeground;
 };

--- a/include/utils/StateUtils.h
+++ b/include/utils/StateUtils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 class State {
 public:
     static void init();

--- a/include/utils/StateUtils.h
+++ b/include/utils/StateUtils.h
@@ -5,6 +5,7 @@ public:
     static void init();
     static bool AppRunning();
     static void shutdown();
+    static void registerProcUICallbacks();
 
 private:
     static bool aroma;

--- a/include/utils/StateUtils.h
+++ b/include/utils/StateUtils.h
@@ -6,6 +6,8 @@ public:
     static bool AppRunning();
     static void shutdown();
     static void registerProcUICallbacks();
+    static uint32_t ConsoleProcCallbackAcquired(void *context);
+    static uint32_t ConsoleProcCallbackReleased(void *context);
 
 private:
     static bool aroma;

--- a/include/version.h
+++ b/include/version.h
@@ -2,4 +2,4 @@
 
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 6
-#define VERSION_MICRO 1
+#define VERSION_MICRO 2

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 #include <savemng.h>
 #include <sndcore2/core.h>
 #include <utils/DrawUtils.h>
+#include <utils/Colors.h>
 #include <utils/InputUtils.h>
 #include <utils/LanguageUtils.h>
 #include <utils/StateUtils.h>
@@ -393,6 +394,8 @@ int main() {
     if (DrawUtils::LogConsoleInit()) {
         OSFatal("Failed to initialize OSSCreen");
     }
+
+    State::registerProcUICallbacks();
 
     if (!DrawUtils::initFont()) {
         OSFatal("Failed to init font");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,10 +91,11 @@ static Title *loadWiiUTitles(int run) {
                         path = StringUtils::stringFormat("%s/usr/save/%08x/%s/meta/meta.xml", (i == 0) ? getUSB().c_str() : "storage_mlc01:", highIDs[a],
                                                          data->d_name);
                         if (checkEntry(path.c_str()) == 1) {
-                            for (int i = 0; i < usable; i++) {
-                                if (contains(highIDs, savesl[i].highID) &&
-                                    (strtoul(data->d_name, nullptr, 16) == savesl[i].lowID)) {
-                                    savesl[i].found = true;
+                            for (int ii = 0; ii < usable; ii++) {
+                                if (contains(highIDs, savesl[ii].highID) &&
+                                    (strtoul(data->d_name, nullptr, 16) == savesl[ii].lowID) &&
+                                    savesl[ii].dev == i ) {
+                                    savesl[ii].found = true;
                                     tNoSave--;
                                     break;
                                 }
@@ -109,7 +110,7 @@ static Title *loadWiiUTitles(int run) {
     }
 
     foundCount += tNoSave;
-    auto *saves = (Saves *) malloc((foundCount + tNoSave) * sizeof(Saves));
+    auto *saves = (Saves *) malloc((foundCount) * sizeof(Saves));
     if (saves == nullptr) {
         promptError(LanguageUtils::gettext("Out of memory."));
         return nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,3 @@
-#include <coreinit/debug.h>
-#include <coreinit/mcp.h>
-#include <coreinit/screen.h>
 #include <cstdlib>
 #include <cstring>
 #include <icon.h>
@@ -16,6 +13,9 @@
 #include <utils/StateUtils.h>
 #include <utils/StringUtils.h>
 #include <version.h>
+#include <coreinit/debug.h>
+#include <coreinit/mcp.h>
+#include <coreinit/screen.h>
 
 static int wiiuTitlesCount = 0, vWiiTitlesCount = 0;
 

--- a/src/menu/WiiUTitleListState.cpp
+++ b/src/menu/WiiUTitleListState.cpp
@@ -6,6 +6,7 @@
 #include <utils/InputUtils.h>
 #include <utils/LanguageUtils.h>
 #include <utils/StringUtils.h>
+#include <utils/Colors.h>
 
 #define MAX_TITLE_SHOW 14
 static int cursorPos = 0;

--- a/src/menu/vWiiTitleListState.cpp
+++ b/src/menu/vWiiTitleListState.cpp
@@ -5,6 +5,7 @@
 #include <savemng.h>
 #include <utils/InputUtils.h>
 #include <utils/LanguageUtils.h>
+#include <utils/Colors.h>
 
 #define MAX_TITLE_SHOW 14
 static int cursorPos = 0;

--- a/src/savemng.cpp
+++ b/src/savemng.cpp
@@ -10,6 +10,7 @@
 #include <utils/StringUtils.h>
 #include <malloc.h>
 
+
 #define __FSAShimSend      ((FSError(*)(FSAShimBuffer *, uint32_t))(0x101C400 + 0x042d90))
 #define IO_MAX_FILE_BUFFER (1024 * 1024) // 1 MB
 
@@ -202,14 +203,18 @@ static bool folderEmpty(const char *fPath) {
     if (dir == nullptr)
         return false;
 
-    int c = 0;
+    bool empty = true;
     struct dirent *data;
-    while ((data = readdir(dir)) != nullptr)
-        if (++c > 2)
-            break;
+    while ((data = readdir(dir)) != nullptr) {
+        // rewritten to work wether ./.. are returned or not
+        if(strcmp(data->d_name,".") == 0 || strcmp(data->d_name,"..") == 0)
+            continue;
+        empty = false;
+        break;
+    }
 
     closedir(dir);
-    return c < 3;
+    return empty;
 }
 
 static bool createFolder(const char *path) {

--- a/src/savemng.cpp
+++ b/src/savemng.cpp
@@ -857,16 +857,23 @@ void copySavedata(Title *title, Title *titleb, int8_t allusers, int8_t allusers_
     std::string srcPath = StringUtils::stringFormat("%s/%08x/%08x/%s", path.c_str(), highID, lowID, "user");
     std::string dstPath = StringUtils::stringFormat("%s/%08x/%08x/%s", pathb.c_str(), highIDb, lowIDb, "user");
     createFolderUnlocked(dstPath);
-    FSAMakeQuotaFromDir(srcPath.c_str(), dstPath.c_str(), titleb->accountSaveSize);
 
-    if (allusers > -1)
-        if (common)
+    if (allusers > -1)  {
+        if (common) {
+            FSAMakeQuota(handle, newlibtoFSA(dstPath + "/common").c_str(), 0x666, titleb->accountSaveSize);
             if (!copyDir(srcPath + "/common", dstPath + "/common"))
                 promptError(LanguageUtils::gettext("Common save not found."));
+        }
+        srcPath.append(StringUtils::stringFormat("/%s", wiiuacc[allusers].persistentID));
+        dstPath.append(StringUtils::stringFormat("/%s", wiiuacc[allusers_d].persistentID));
+        FSAMakeQuota(handle, newlibtoFSA(dstPath).c_str(), 0x666, titleb->accountSaveSize);
+    } else {
+        FSAMakeQuotaFromDir(srcPath.c_str(), dstPath.c_str(), titleb->accountSaveSize);
+    }
 
-    if (!copyDir(srcPath + StringUtils::stringFormat("/%s", wiiuacc[allusers].persistentID),
-                 dstPath + StringUtils::stringFormat("/%s", wiiuacc[allusers_d].persistentID)))
+    if (!copyDir(srcPath, dstPath))
         promptError(LanguageUtils::gettext("Copy failed."));
+    
     if (!titleb->saveInit) {
         std::string userPath = StringUtils::stringFormat("%s/%08x/%08x/user", pathb.c_str(), highIDb, lowIDb);
 

--- a/src/savemng.cpp
+++ b/src/savemng.cpp
@@ -1012,19 +1012,24 @@ void restoreSavedata(Title *title, uint8_t slot, int8_t sdusers, int8_t allusers
         srcPath = getBackupPath(highID, lowID, slot);
     std::string dstPath = StringUtils::stringFormat("%s/%08x/%08x/%s", path.c_str(), highID, lowID, isWii ? "data" : "user");
     createFolderUnlocked(dstPath);
-    FSAMakeQuotaFromDir(srcPath.c_str(), dstPath.c_str(), title->accountSaveSize);
-
+    
     if ((sdusers > -1) && !isWii) {
         if (common) {
+            FSAMakeQuota(handle, newlibtoFSA(dstPath + "/common").c_str(), 0x666, title->accountSaveSize);
             if (!copyDir(srcPath + "/common", dstPath + "/common"))
                 promptError(LanguageUtils::gettext("Common save not found."));
         }
         srcPath.append(StringUtils::stringFormat("/%s", sdacc[sdusers].persistentID));
         dstPath.append(StringUtils::stringFormat("/%s", wiiuacc[allusers].persistentID));
+        FSAMakeQuota(handle, newlibtoFSA(dstPath).c_str(), 0x666, title->accountSaveSize);
+    } else {
+        FSAMakeQuotaFromDir(srcPath.c_str(), dstPath.c_str(), title->accountSaveSize);
     }
 
     if (!copyDir(srcPath, dstPath))
         promptError(LanguageUtils::gettext("Restore failed."));
+
+
     if (!title->saveInit && !isWii) {
         std::string userPath = StringUtils::stringFormat("%s/%08x/%08x/user", path.c_str(), highID, lowID);
 

--- a/src/savemng.cpp
+++ b/src/savemng.cpp
@@ -8,6 +8,7 @@
 #include <sys/stat.h>
 #include <utils/LanguageUtils.h>
 #include <utils/StringUtils.h>
+#include <utils/Colors.h>
 #include <malloc.h>
 
 

--- a/src/utils/DrawUtils.cpp
+++ b/src/utils/DrawUtils.cpp
@@ -59,9 +59,6 @@ DrawUtils::initScreen()
    OSScreenSetBufferEx(SCREEN_DRC, sBufferDRC);
    DrawUtils::initBuffers(sBufferTV, sBufferDRC);
 
-   OSScreenEnableEx(SCREEN_TV, 1);
-   OSScreenEnableEx(SCREEN_DRC, 1);
-
    for (int i = 0; i<2; i++) // both buffers to black
    {
         DrawUtils::clear(COLOR_BLACK);
@@ -98,6 +95,9 @@ DrawUtils::LogConsoleInit()
    sBufferSizeDRC = OSScreenGetBufferSizeEx(SCREEN_DRC);
 
    initScreen();
+
+   OSScreenEnableEx(SCREEN_TV, 1);
+   OSScreenEnableEx(SCREEN_DRC, 1);
 
    return FALSE;
 }

--- a/src/utils/DrawUtils.cpp
+++ b/src/utils/DrawUtils.cpp
@@ -33,6 +33,7 @@ uint32_t DrawUtils::sBufferSizeDRC = 0;
 static SFT pFont = {};
 
 static Color font_col(0xFFFFFFFF);
+static Color black(0x000000FF);
 
 void *DrawUtils::sBufferTV = NULL, *DrawUtils::sBufferDRC = NULL;
 uint32_t DrawUtils::sBufferSizeTV = 0, DrawUtils::sBufferSizeDRC = 0;
@@ -52,10 +53,25 @@ DrawUtils::ConsoleProcCallbackAcquired(void *context)
       sBufferDRC = MEMAllocFromFrmHeapEx(heap, sBufferSizeDRC, 4);
    }
 
+    
    sConsoleHasForeground = TRUE;
-   DrawUtils::setRedraw(true);
+
    OSScreenSetBufferEx(SCREEN_TV, sBufferTV);
    OSScreenSetBufferEx(SCREEN_DRC, sBufferDRC);
+   DrawUtils::initBuffers(sBufferTV, sBufferDRC);
+
+    OSScreenEnableEx(SCREEN_TV, 1);
+   OSScreenEnableEx(SCREEN_DRC, 1);
+   
+
+   for (int i = 0; i<2; i++) // both buffers to black
+   {
+        DrawUtils::clear(black);
+        DrawUtils::endDraw();
+   }
+
+   DrawUtils::setRedraw(true); // force a redraw when reentering
+
    return 0;
 }
 
@@ -77,12 +93,8 @@ DrawUtils::LogConsoleInit()
    sBufferSizeDRC = OSScreenGetBufferSizeEx(SCREEN_DRC);
 
    ConsoleProcCallbackAcquired(NULL);
-   OSScreenEnableEx(SCREEN_TV, 1);
-   OSScreenEnableEx(SCREEN_DRC, 1);
-
+   
     State::registerProcUICallbacks();
-
-    DrawUtils::initBuffers(sBufferTV, sBufferDRC);
 
    return FALSE;
 }

--- a/src/utils/DrawUtils.cpp
+++ b/src/utils/DrawUtils.cpp
@@ -1,16 +1,14 @@
-#include <coreinit/cache.h>
-#include <coreinit/screen.h>
+#include <utils/DrawUtils.h>
+#include <utils/Colors.h>
 #include <cstdlib>
 #include <cstring>
 #include <memory>
-#include <tga_reader.h>
-#include <utils/DrawUtils.h>
-#include <utils/Colors.h>
 #include <malloc.h>
+#include <tga_reader.h>
 #include <coreinit/debug.h>
-
-#include <coreinit/memheap.h>
 #include <coreinit/cache.h>
+#include <coreinit/screen.h>
+#include <coreinit/memheap.h>
 #include <coreinit/memfrmheap.h>
 #include <coreinit/memory.h>
 #include <proc_ui/procui.h>

--- a/src/utils/DrawUtils.cpp
+++ b/src/utils/DrawUtils.cpp
@@ -59,9 +59,8 @@ DrawUtils::initScreen()
    OSScreenSetBufferEx(SCREEN_DRC, sBufferDRC);
    DrawUtils::initBuffers(sBufferTV, sBufferDRC);
 
-    OSScreenEnableEx(SCREEN_TV, 1);
+   OSScreenEnableEx(SCREEN_TV, 1);
    OSScreenEnableEx(SCREEN_DRC, 1);
-   
 
    for (int i = 0; i<2; i++) // both buffers to black
    {
@@ -99,7 +98,7 @@ DrawUtils::LogConsoleInit()
    sBufferSizeDRC = OSScreenGetBufferSizeEx(SCREEN_DRC);
 
    initScreen();
-   
+
    return FALSE;
 }
 

--- a/src/utils/StateUtils.cpp
+++ b/src/utils/StateUtils.cpp
@@ -1,15 +1,12 @@
+#include <utils/StateUtils.h>
+#include <utils/DrawUtils.h>
 #include <coreinit/core.h>
 #include <coreinit/dynload.h>
 #include <coreinit/foreground.h>
 #include <proc_ui/procui.h>
-#include <utils/StateUtils.h>
-#include <utils/DrawUtils.h>
-#include <coreinit/screen.h>
 #include <whb/proc.h>
 
 #include <string.h>
-
-#include <utils/DrawUtils.h>
 
 
 bool State::aroma = false;

--- a/src/utils/StateUtils.cpp
+++ b/src/utils/StateUtils.cpp
@@ -11,6 +11,9 @@
 
 #include <utils/DrawUtils.h>
 
+#include <whb/log_udp.h>
+#include <whb/log.h>
+
 bool State::aroma = false;
 
 void State::init() {
@@ -25,10 +28,22 @@ void State::init() {
 }
 
 
+uint32_t
+State::ConsoleProcCallbackAcquired(void *context)
+{
+    return DrawUtils::initScreen();
+}
+
+uint32_t
+State::ConsoleProcCallbackReleased(void *context)
+{
+    return DrawUtils::deinitScreen();
+}
+
 void State::registerProcUICallbacks() {
     if (aroma) {
-        ProcUIRegisterCallback(PROCUI_CALLBACK_ACQUIRE, DrawUtils::ConsoleProcCallbackAcquired, NULL, 100);
-        ProcUIRegisterCallback(PROCUI_CALLBACK_RELEASE, DrawUtils::ConsoleProcCallbackReleased, NULL, 100);
+        ProcUIRegisterCallback(PROCUI_CALLBACK_ACQUIRE, ConsoleProcCallbackAcquired, NULL, 100);
+        ProcUIRegisterCallback(PROCUI_CALLBACK_RELEASE, ConsoleProcCallbackReleased, NULL, 100);
     }
 }
 
@@ -43,6 +58,7 @@ bool State::AppRunning() {
                     break;
                 case PROCUI_STATUS_RELEASE_FOREGROUND:
                     // Free up MEM1 to next foreground app, deinit screen, etc.
+                    WHBLogPrintf("ToProcUIDoneRelease");
                     ProcUIDrawDoneRelease();
                     break;
                 case PROCUI_STATUS_IN_FOREGROUND:

--- a/src/utils/StateUtils.cpp
+++ b/src/utils/StateUtils.cpp
@@ -11,8 +11,6 @@
 
 #include <utils/DrawUtils.h>
 
-#include <whb/log_udp.h>
-#include <whb/log.h>
 
 bool State::aroma = false;
 
@@ -58,7 +56,6 @@ bool State::AppRunning() {
                     break;
                 case PROCUI_STATUS_RELEASE_FOREGROUND:
                     // Free up MEM1 to next foreground app, deinit screen, etc.
-                    WHBLogPrintf("ToProcUIDoneRelease");
                     ProcUIDrawDoneRelease();
                     break;
                 case PROCUI_STATUS_IN_FOREGROUND:

--- a/src/utils/StateUtils.cpp
+++ b/src/utils/StateUtils.cpp
@@ -3,7 +3,13 @@
 #include <coreinit/foreground.h>
 #include <proc_ui/procui.h>
 #include <utils/StateUtils.h>
+#include <utils/DrawUtils.h>
+#include <coreinit/screen.h>
 #include <whb/proc.h>
+
+#include <string.h>
+
+#include <utils/DrawUtils.h>
 
 bool State::aroma = false;
 
@@ -16,6 +22,14 @@ void State::init() {
         OSEnableHomeButtonMenu(true);
     } else
         WHBProcInit();
+}
+
+
+void State::registerProcUICallbacks() {
+    if (aroma) {
+        ProcUIRegisterCallback(PROCUI_CALLBACK_ACQUIRE, DrawUtils::ConsoleProcCallbackAcquired, NULL, 100);
+        ProcUIRegisterCallback(PROCUI_CALLBACK_RELEASE, DrawUtils::ConsoleProcCallbackReleased, NULL, 100);
+    }
 }
 
 bool State::AppRunning() {
@@ -51,3 +65,5 @@ void State::shutdown() {
         WHBProcShutdown();
     ProcUIShutdown();
 }
+
+


### PR DESCRIPTION
This PR address the following problems:

- Crash when initializing the application if  savedata for a installed title is stored in  nand and in usb  ( [PR](https://github.com/Xpl0itU/savemii/pull/59))
- Crash when exiting the application ([PR](https://github.com/Xpl0itU/savemii/pull/56))
- Comon savedata is not always detected when performing backup/restore from user to user 
- Restore from/to specific user creates fake folders
- copyToOtherDevice fails if allusers is selected

----

Some technical detail about the fixes:
- Detailed explanations for the two first issues can be found in the referenced PR.
- Common savedata issue is due to a problem in the condition to detect empty directories.
- Fake folders issue is due to the default creation of quotas for all source users even if from/to user option is selected 
- copySavedata don't take into account the allusers option that can be selected from the menu

I will appreciate if you can  review the code. Any comment will be appreciated. 