### PR TITLE
Added nunchuk support.

### DIFF
--- a/include/utils/InputUtils.h
+++ b/include/utils/InputUtils.h
@@ -32,7 +32,6 @@ public:
     bool get(ButtonState state, Button button) const __attribute__((hot));
 
 private:
-    VPADStatus vpad_status;
-    VPADReadError vpad_error;
-    KPADStatus kpad[4], kpad_status;
+    VPADStatus vpad_status = {};
+    KPADStatus kpad_status = {};
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,7 +66,7 @@ static void getWiiUSerialId() {
             Metadata::thisConsoleSerialId = std::string(sysProd.code_id) + sysProd.serial_id;
         }
         MCP_Close(mcpHandle);
-    } 
+    }
 }
 
 static Title *loadWiiUTitles(int run) {
@@ -261,7 +261,7 @@ static Title *loadWiiUTitles(int run) {
         titles[wiiuTitlesCount].isTitleOnUSB = isTitleOnUSB;
         titles[wiiuTitlesCount].listID = wiiuTitlesCount;
         if (loadTitleIcon(&titles[wiiuTitlesCount]) < 0)
-            titles[wiiuTitlesCount].iconBuf = nullptr; 
+            titles[wiiuTitlesCount].iconBuf = nullptr;
 
         std::string fwpath = StringUtils::stringFormat("%s/usr/title/000%x/%x/code/fw.img",
                     titles[wiiuTitlesCount].isTitleOnUSB ? getUSB().c_str() : "storage_mlc01:",
@@ -482,7 +482,7 @@ std::vector<const char*> initMessageList;
 void addInitMessage(const char* newMessage) {
 
     initMessageList.push_back(newMessage);
-    
+
     DrawUtils::beginDraw();
     DrawUtils::clear(COLOR_BLACK);
     consolePrintPosAligned(5, 0, 1, "SaveMii v%u.%u.%u%c", VERSION_MAJOR, VERSION_MINOR, VERSION_MICRO, VERSION_FIX);
@@ -519,19 +519,19 @@ void addInitMessageWithIcon(const char* newMessage) {
 
 int main() {
 
-#ifdef DEBUG    
+#ifdef DEBUG
     WHBLogUdpInit();
     WHBLogPrintf("Hello from savemii!");
 #endif
 
 // freezes console to some users
 /*
-    AXInit();    
+    AXInit();
     AXQuit();
-*/    
+*/
 
     State::init();
-    
+
     if (DrawUtils::LogConsoleInit()) {
         OSFatal("Failed to initialize OSSCreen");
     }
@@ -559,7 +559,7 @@ int main() {
     addInitMessage("... can take several seconds on some SDs");
 
     GlobalCfg::global = std::make_unique<GlobalCfg>("cfg");
-    
+
     if (! GlobalCfg::global->init()) {
         promptError("Failed to init global config file\n  Check SD card and sd:/wiiu/backups/savemiiCfg folder.");
         romfsExit();
@@ -576,7 +576,6 @@ int main() {
 
     addInitMessage(LanguageUtils::gettext("Initializing WPAD and KAPD"));
 
-    WPADInit();
     KPADInit();
     WPADEnableURCC(1);
 
@@ -620,7 +619,7 @@ int main() {
     ExcludesCfg::wiiExcludes = std::make_unique<ExcludesCfg>("wiiExcludes",wiititles,vWiiTitlesCount);
     ExcludesCfg::wiiuExcludes->init();
     ExcludesCfg::wiiExcludes->init();
-    
+
     resetMessageList();
 
     Input input{};
@@ -662,5 +661,6 @@ int main() {
     DrawUtils::LogConsoleFree();
 
     State::shutdown();
+    KPADShutdown();
     return 0;
 }

--- a/src/utils/InputUtils.cpp
+++ b/src/utils/InputUtils.cpp
@@ -1,138 +1,155 @@
 #include <utils/InputUtils.h>
 
 void Input::read() {
-    VPADRead(VPAD_CHAN_0, &vpad_status, 1, &vpad_error);
-    if (vpad_error != VPAD_READ_SUCCESS)
-        memset(&vpad_status, 0, sizeof(VPADStatus));
-
-    memset(&kpad_status, 0, sizeof(KPADStatus));
-    WPADExtensionType controllerType;
-    for (int i = 0; i < 4; i++) {
-        if (WPADProbe((WPADChan) i, &controllerType) == 0) {
-            KPADRead((WPADChan) i, &kpad_status, 1);
-            break;
-        }
-    }
+    VPADRead(VPAD_CHAN_0, &vpad_status, 1, nullptr);
+    KPADRead(WPAD_CHAN_0, &kpad_status, 1);
 }
 
 bool Input::get(ButtonState state, Button button) const {
-    uint32_t vpadState = 0;
-    uint32_t kpadState = 0;
+    uint32_t vpadState        = 0;
+    uint32_t kpadCoreState    = 0;
     uint32_t kpadClassicState = 0;
-    uint32_t kpadProState = 0;
+    uint32_t kpadNunchukState = 0;
+    uint32_t kpadProState     = 0;
 
-    switch (state) {
-        case TRIGGER:
-            vpadState = vpad_status.trigger;
-            kpadState = kpad_status.trigger;
-            kpadClassicState = kpad_status.classic.trigger;
-            kpadProState = kpad_status.pro.trigger;
-            break;
-        case HOLD:
-            vpadState = vpad_status.hold;
-            kpadState = kpad_status.hold;
-            kpadClassicState = kpad_status.classic.hold;
-            kpadProState = kpad_status.pro.hold;
-            break;
-        case RELEASE:
-            vpadState = vpad_status.release;
-            kpadState = kpad_status.release;
-            kpadClassicState = kpad_status.classic.release;
-            kpadProState = kpad_status.pro.release;
-            break;
-    }
-    if ((vpadState != 0) || (kpadState != 0) || (kpadClassicState != 0) || (kpadProState != 0)) {
-        switch (button) {
-            case PAD_BUTTON_A:
-                if (vpadState & VPAD_BUTTON_A) return true;
-                if (kpadState & WPAD_BUTTON_A) return true;
-                if (kpadClassicState & WPAD_CLASSIC_BUTTON_A) return true;
-                if (kpadProState & WPAD_PRO_BUTTON_A) return true;
+    auto examine = [state](const auto& status) -> uint32_t
+    {
+        switch (state) {
+            case TRIGGER:
+                return status.trigger;
+            case HOLD:
+                return status.hold;
+            case RELEASE:
+                return status.release;
+            default:
+                return 0;
+        }
+    };
+
+    if (!vpad_status.error)
+        vpadState = examine(vpad_status);
+
+    if (!kpad_status.error) {
+        switch (kpad_status.extensionType) {
+            case WPAD_EXT_CORE:
+                kpadCoreState = examine(kpad_status);
                 break;
-            case PAD_BUTTON_B:
-                if (vpadState & VPAD_BUTTON_B) return true;
-                if (kpadState & WPAD_BUTTON_B) return true;
-                if (kpadClassicState & WPAD_CLASSIC_BUTTON_B) return true;
-                if (kpadProState & WPAD_PRO_BUTTON_B) return true;
+            case WPAD_EXT_NUNCHUK:
+                kpadCoreState    = examine(kpad_status);
+                kpadNunchukState = examine(kpad_status.nunchuk);
                 break;
-            case PAD_BUTTON_X:
-                if (vpadState & VPAD_BUTTON_X) return true;
-                if (kpadState & WPAD_BUTTON_1) return true;
-                if (kpadClassicState & WPAD_CLASSIC_BUTTON_X) return true;
-                if (kpadProState & WPAD_PRO_BUTTON_X) return true;
+            case WPAD_EXT_CLASSIC:
+                kpadCoreState    = examine(kpad_status);
+                kpadClassicState = examine(kpad_status.classic);
                 break;
-            case PAD_BUTTON_Y:
-                if (vpadState & VPAD_BUTTON_Y) return true;
-                if (kpadState & WPAD_BUTTON_2) return true;
-                if (kpadClassicState & WPAD_CLASSIC_BUTTON_Y) return true;
-                if (kpadProState & WPAD_PRO_BUTTON_Y) return true;
-                break;
-            case PAD_BUTTON_UP:
-                if (vpadState & VPAD_BUTTON_UP) return true;
-                if (vpadState & VPAD_STICK_L_EMULATION_UP) return true;
-                if (kpadState & WPAD_BUTTON_UP) return true;
-                if (kpadClassicState & WPAD_CLASSIC_BUTTON_UP) return true;
-                if (kpadClassicState & WPAD_CLASSIC_STICK_L_EMULATION_UP) return true;
-                if (kpadProState & WPAD_PRO_BUTTON_UP) return true;
-                if (kpadProState & WPAD_PRO_STICK_L_EMULATION_UP) return true;
-                break;
-            case PAD_BUTTON_DOWN:
-                if (vpadState & VPAD_BUTTON_DOWN) return true;
-                if (vpadState & VPAD_STICK_L_EMULATION_DOWN) return true;
-                if (kpadState & WPAD_BUTTON_DOWN) return true;
-                if (kpadClassicState & WPAD_CLASSIC_BUTTON_DOWN) return true;
-                if (kpadClassicState & WPAD_CLASSIC_STICK_L_EMULATION_DOWN) return true;
-                if (kpadProState & WPAD_PRO_BUTTON_DOWN) return true;
-                if (kpadProState & WPAD_PRO_STICK_L_EMULATION_DOWN) return true;
-                break;
-            case PAD_BUTTON_LEFT:
-                if (vpadState & VPAD_BUTTON_LEFT) return true;
-                if (vpadState & VPAD_STICK_L_EMULATION_LEFT) return true;
-                if (kpadState & WPAD_BUTTON_LEFT) return true;
-                if (kpadClassicState & WPAD_CLASSIC_BUTTON_LEFT) return true;
-                if (kpadClassicState & WPAD_CLASSIC_STICK_L_EMULATION_LEFT) return true;
-                if (kpadProState & WPAD_PRO_BUTTON_LEFT) return true;
-                if (kpadProState & WPAD_PRO_STICK_L_EMULATION_LEFT) return true;
-                break;
-            case PAD_BUTTON_RIGHT:
-                if (vpadState & VPAD_BUTTON_RIGHT) return true;
-                if (vpadState & VPAD_STICK_L_EMULATION_RIGHT) return true;
-                if (kpadState & WPAD_BUTTON_RIGHT) return true;
-                if (kpadClassicState & WPAD_CLASSIC_BUTTON_RIGHT) return true;
-                if (kpadClassicState & WPAD_CLASSIC_STICK_L_EMULATION_RIGHT) return true;
-                if (kpadProState & WPAD_PRO_BUTTON_RIGHT) return true;
-                if (kpadProState & WPAD_PRO_STICK_L_EMULATION_RIGHT) return true;
-                break;
-            case PAD_BUTTON_L:
-                if (vpadState & VPAD_BUTTON_L) return true;
-                if (kpadClassicState & WPAD_CLASSIC_BUTTON_L) return true;
-                if (kpadProState & WPAD_PRO_TRIGGER_L) return true;
-                break;
-            case PAD_BUTTON_R:
-                if (vpadState & VPAD_BUTTON_R) return true;
-                if (kpadState & WPAD_BUTTON_PLUS) return true;
-                if (kpadClassicState & WPAD_CLASSIC_BUTTON_R) return true;
-                if (kpadProState & WPAD_PRO_TRIGGER_R) return true;
-                break;
-            case PAD_BUTTON_PLUS:
-                if (vpadState & VPAD_BUTTON_PLUS) return true;
-                if (kpadState & WPAD_BUTTON_PLUS) return true;
-                if (kpadClassicState & WPAD_CLASSIC_BUTTON_PLUS) return true;
-                if (kpadProState & WPAD_PRO_BUTTON_PLUS) return true;
-                break;
-            case PAD_BUTTON_MINUS:
-                if (vpadState & VPAD_BUTTON_MINUS) return true;
-                if (kpadState & WPAD_BUTTON_MINUS) return true;
-                if (kpadClassicState & WPAD_CLASSIC_BUTTON_MINUS) return true;
-                if (kpadProState & WPAD_PRO_BUTTON_MINUS) return true;
-                break;    
-            case PAD_BUTTON_ANY:
-                if (vpadState) return true;
-                if (kpadState) return true;
-                if (kpadClassicState) return true;
-                if (kpadProState) return true;
+            case WPAD_EXT_PRO_CONTROLLER:
+                kpadProState = examine(kpad_status.pro);
                 break;
         }
     }
+
+    if (!vpadState &&
+        !kpadCoreState &&
+        !kpadClassicState &&
+        !kpadNunchukState &&
+        !kpadProState)
+        return false;
+
+    switch (button) {
+        case PAD_BUTTON_A:
+            if (vpadState        & VPAD_BUTTON_A)         return true;
+            if (kpadCoreState    & WPAD_BUTTON_A)         return true;
+            if (kpadClassicState & WPAD_CLASSIC_BUTTON_A) return true;
+            if (kpadProState     & WPAD_PRO_BUTTON_A)     return true;
+            break;
+        case PAD_BUTTON_B:
+            if (vpadState        & VPAD_BUTTON_B)         return true;
+            if (kpadCoreState    & WPAD_BUTTON_B)         return true;
+            if (kpadClassicState & WPAD_CLASSIC_BUTTON_B) return true;
+            if (kpadProState     & WPAD_PRO_BUTTON_B)     return true;
+            break;
+        case PAD_BUTTON_X:
+            if (vpadState        & VPAD_BUTTON_X)         return true;
+            if (kpadCoreState    & WPAD_BUTTON_1)         return true;
+            if (kpadClassicState & WPAD_CLASSIC_BUTTON_X) return true;
+            if (kpadProState     & WPAD_PRO_BUTTON_X)     return true;
+            break;
+        case PAD_BUTTON_Y:
+            if (vpadState        & VPAD_BUTTON_Y)         return true;
+            if (kpadCoreState    & WPAD_BUTTON_2)         return true;
+            if (kpadClassicState & WPAD_CLASSIC_BUTTON_Y) return true;
+            if (kpadProState     & WPAD_PRO_BUTTON_Y)     return true;
+            break;
+        case PAD_BUTTON_UP:
+            if (vpadState        & VPAD_BUTTON_UP)                    return true;
+            if (vpadState        & VPAD_STICK_L_EMULATION_UP)         return true;
+            if (kpadCoreState    & WPAD_BUTTON_UP)                    return true;
+            if (kpadClassicState & WPAD_CLASSIC_BUTTON_UP)            return true;
+            if (kpadClassicState & WPAD_CLASSIC_STICK_L_EMULATION_UP) return true;
+            if (kpadNunchukState & WPAD_NUNCHUK_STICK_EMULATION_UP)   return true;
+            if (kpadProState     & WPAD_PRO_BUTTON_UP)                return true;
+            if (kpadProState     & WPAD_PRO_STICK_L_EMULATION_UP)     return true;
+            break;
+        case PAD_BUTTON_DOWN:
+            if (vpadState        & VPAD_BUTTON_DOWN)                    return true;
+            if (vpadState        & VPAD_STICK_L_EMULATION_DOWN)         return true;
+            if (kpadCoreState    & WPAD_BUTTON_DOWN)                    return true;
+            if (kpadClassicState & WPAD_CLASSIC_BUTTON_DOWN)            return true;
+            if (kpadClassicState & WPAD_CLASSIC_STICK_L_EMULATION_DOWN) return true;
+            if (kpadNunchukState & WPAD_NUNCHUK_STICK_EMULATION_DOWN)   return true;
+            if (kpadProState     & WPAD_PRO_BUTTON_DOWN)                return true;
+            if (kpadProState     & WPAD_PRO_STICK_L_EMULATION_DOWN)     return true;
+            break;
+        case PAD_BUTTON_LEFT:
+            if (vpadState        & VPAD_BUTTON_LEFT)                    return true;
+            if (vpadState        & VPAD_STICK_L_EMULATION_LEFT)         return true;
+            if (kpadCoreState    & WPAD_BUTTON_LEFT)                    return true;
+            if (kpadClassicState & WPAD_CLASSIC_BUTTON_LEFT)            return true;
+            if (kpadClassicState & WPAD_CLASSIC_STICK_L_EMULATION_LEFT) return true;
+            if (kpadNunchukState & WPAD_NUNCHUK_STICK_EMULATION_LEFT)   return true;
+            if (kpadProState     & WPAD_PRO_BUTTON_LEFT)                return true;
+            if (kpadProState     & WPAD_PRO_STICK_L_EMULATION_LEFT)     return true;
+            break;
+        case PAD_BUTTON_RIGHT:
+            if (vpadState        & VPAD_BUTTON_RIGHT)                    return true;
+            if (vpadState        & VPAD_STICK_L_EMULATION_RIGHT)         return true;
+            if (kpadCoreState    & WPAD_BUTTON_RIGHT)                    return true;
+            if (kpadClassicState & WPAD_CLASSIC_BUTTON_RIGHT)            return true;
+            if (kpadClassicState & WPAD_CLASSIC_STICK_L_EMULATION_RIGHT) return true;
+            if (kpadNunchukState & WPAD_NUNCHUK_STICK_EMULATION_RIGHT)   return true;
+            if (kpadProState     & WPAD_PRO_BUTTON_RIGHT)                return true;
+            if (kpadProState     & WPAD_PRO_STICK_L_EMULATION_RIGHT)     return true;
+            break;
+        case PAD_BUTTON_L:
+            if (vpadState        & VPAD_BUTTON_L)         return true;
+            if (kpadClassicState & WPAD_CLASSIC_BUTTON_L) return true;
+            if (kpadProState     & WPAD_PRO_BUTTON_L)     return true;
+            break;
+        case PAD_BUTTON_R:
+            if (vpadState        & VPAD_BUTTON_R)         return true;
+            if (kpadCoreState    & WPAD_BUTTON_PLUS)      return true;
+            if (kpadClassicState & WPAD_CLASSIC_BUTTON_R) return true;
+            if (kpadProState     & WPAD_PRO_BUTTON_R)     return true;
+            break;
+        case PAD_BUTTON_PLUS:
+            if (vpadState        & VPAD_BUTTON_PLUS)         return true;
+            if (kpadCoreState    & WPAD_BUTTON_PLUS)         return true;
+            if (kpadClassicState & WPAD_CLASSIC_BUTTON_PLUS) return true;
+            if (kpadProState     & WPAD_PRO_BUTTON_PLUS)     return true;
+            break;
+        case PAD_BUTTON_MINUS:
+            if (vpadState        & VPAD_BUTTON_MINUS)         return true;
+            if (kpadCoreState    & WPAD_BUTTON_MINUS)         return true;
+            if (kpadClassicState & WPAD_CLASSIC_BUTTON_MINUS) return true;
+            if (kpadProState     & WPAD_PRO_BUTTON_MINUS)     return true;
+            break;
+        case PAD_BUTTON_ANY:
+            return vpadState
+                || kpadCoreState
+                || kpadClassicState
+                || kpadNunchukState
+                || kpadProState;
+    }
+
     return false;
 }


### PR DESCRIPTION
This adds support to the nunchuk extension.
The input reading class was changed a bit to use the `error` field of the status objects. As far as I can tell, it shows the same error code as the explicit error argument in `VPADRead()` and `KPADReadEx()`, so we don't need to store another copy of the error.
It's also hardcoded to only respond to the first wiimote; this ain't a multiplayer game, it's hard to justify responding to 4 different wiimotes.